### PR TITLE
Add build file exclusion

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,6 +132,10 @@
                             <Vaadin-Package-Version>1</Vaadin-Package-Version>
                         </manifestEntries>
                     </archive>
+                    <!-- Generated file that shouldn't be included in add-ons -->
+                    <excludes>
+                        <exclude>META-INF/VAADIN/config/flow-build-info.json</exclude>
+                    </excludes>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
Exclude the flow-build-info.json as it contains build time data.

After new version of add-on 
Fixes #29 