### PR TITLE
Adding Support for combining line Charts with others #32

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,5 +20,5 @@
     "raw-loader": "3.0.0",
     "compression-webpack-plugin": "3.0.0"
   },
-  "vaadinAppPackageHash": "4af046beaf50e05798ee716f27869eafab74956f3103fc58b55f7e030e526d9d"
+  "vaadinAppPackageHash": "d774ac42f620f1bf884969040b3b79e479f55d4d86ed7a084f3aa0468d56b078"
 }

--- a/src/main/java/com/github/appreciated/apexcharts/config/Fill.java
+++ b/src/main/java/com/github/appreciated/apexcharts/config/Fill.java
@@ -8,11 +8,11 @@ import java.util.List;
 
 public class Fill {
     private List<String> colors;
-    private Double opacity;
-    private String type;
-    private Gradient gradient;
-    private Image image;
-    private Pattern pattern;
+    private Double[] opacity;
+    private String[] type;
+    private Gradient[] gradient;
+    private Image[] image;
+    private Pattern[] pattern;
 
     public Fill() {
     }
@@ -21,23 +21,23 @@ public class Fill {
         return colors;
     }
 
-    public Double getOpacity() {
+    public Double[] getOpacity() {
         return opacity;
     }
 
-    public String getType() {
+    public String[] getType() {
         return type;
     }
 
-    public Gradient getGradient() {
+    public Gradient[] getGradient() {
         return gradient;
     }
 
-    public Image getImage() {
+    public Image[] getImage() {
         return image;
     }
 
-    public Pattern getPattern() {
+    public Pattern[] getPattern() {
         return pattern;
     }
 
@@ -45,23 +45,23 @@ public class Fill {
         this.colors = colors;
     }
 
-    public void setOpacity(Double opacity) {
+    public void setOpacity(Double... opacity) {
         this.opacity = opacity;
     }
 
-    public void setType(String type) {
+    public void setType(String... type) {
         this.type = type;
     }
 
-    public void setGradient(Gradient gradient) {
+    public void setGradient(Gradient... gradient) {
         this.gradient = gradient;
     }
 
-    public void setImage(Image image) {
+    public void setImage(Image... image) {
         this.image = image;
     }
 
-    public void setPattern(Pattern pattern) {
+    public void setPattern(Pattern... pattern) {
         this.pattern = pattern;
     }
 

--- a/src/main/java/com/github/appreciated/apexcharts/config/builder/FillBuilder.java
+++ b/src/main/java/com/github/appreciated/apexcharts/config/builder/FillBuilder.java
@@ -9,11 +9,11 @@ import java.util.List;
 
 public class FillBuilder {
     private List<String> colors;
-    private Double opacity;
-    private String type;
-    private Gradient gradient;
-    private Image image;
-    private Pattern pattern;
+    private Double[] opacity;
+    private String[] type;
+    private Gradient[] gradient;
+    private Image[] image;
+    private Pattern[] pattern;
 
     private FillBuilder() {
     }
@@ -27,27 +27,27 @@ public class FillBuilder {
         return this;
     }
 
-    public FillBuilder withOpacity(Double opacity) {
+    public FillBuilder withOpacity(Double... opacity) {
         this.opacity = opacity;
         return this;
     }
 
-    public FillBuilder withType(String type) {
+    public FillBuilder withType(String... type) {
         this.type = type;
         return this;
     }
 
-    public FillBuilder withGradient(Gradient gradient) {
+    public FillBuilder withGradient(Gradient... gradient) {
         this.gradient = gradient;
         return this;
     }
 
-    public FillBuilder withImage(Image image) {
+    public FillBuilder withImage(Image... image) {
         this.image = image;
         return this;
     }
 
-    public FillBuilder withPattern(Pattern pattern) {
+    public FillBuilder withPattern(Pattern... pattern) {
         this.pattern = pattern;
         return this;
     }

--- a/src/main/java/com/github/appreciated/apexcharts/config/builder/SeriesBuilder.java
+++ b/src/main/java/com/github/appreciated/apexcharts/config/builder/SeriesBuilder.java
@@ -1,0 +1,40 @@
+package com.github.appreciated.apexcharts.config.builder;
+
+import com.github.appreciated.apexcharts.config.series.SeriesType;
+import com.github.appreciated.apexcharts.helper.Series;
+
+public class SeriesBuilder<T> {
+	private String name;
+	private SeriesType type;
+	private T[] data;
+
+    private SeriesBuilder() {
+    }
+
+    public static SeriesBuilder<?> get() {
+        return new SeriesBuilder();
+    }
+
+    public SeriesBuilder<T> withName(String name) {
+        this.name = name;
+        return this;
+    }
+    
+    public SeriesBuilder<T> withType(SeriesType type) {
+        this.type = type;
+        return this;
+    }
+    
+    public SeriesBuilder<T> withData(T... data) {
+        this.data = data;
+        return this;
+    }
+
+    public Series<T> build() {
+        Series<T> series = new Series<T>();
+        series.setName(name);
+        series.setType(type);
+        series.setData(data);
+        return series;
+    }
+}

--- a/src/main/java/com/github/appreciated/apexcharts/config/series/SeriesType.java
+++ b/src/main/java/com/github/appreciated/apexcharts/config/series/SeriesType.java
@@ -1,0 +1,12 @@
+package com.github.appreciated.apexcharts.config.series;
+
+public enum SeriesType {
+	line("line"),
+    area("area"),
+    column("column");
+    private final String name;
+
+    SeriesType(String name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/com/github/appreciated/apexcharts/helper/Series.java
+++ b/src/main/java/com/github/appreciated/apexcharts/helper/Series.java
@@ -1,7 +1,10 @@
 package com.github.appreciated.apexcharts.helper;
 
+import com.github.appreciated.apexcharts.config.series.SeriesType;
+
 public class Series<T> {
-    private String name;
+	private String name;
+    private SeriesType type;
     private T[] data;
 
     public Series() {
@@ -13,7 +16,12 @@ public class Series<T> {
     }
 
     public Series(String name, T... data) {
+    	this(name, null, data);
+    }
+    
+    public Series(String name, SeriesType type, T... data) {
         this.name = name;
+        this.type = type;
         this.data = data;
     }
 
@@ -25,7 +33,15 @@ public class Series<T> {
         this.name = name;
     }
 
-    public T[] getData() {
+    public SeriesType getType() {
+		return type;
+	}
+
+	public void setType(SeriesType type) {
+		this.type = type;
+	}
+
+	public T[] getData() {
         return data;
     }
 

--- a/src/test/java/com/github/appreciated/ExampleChartGenerator.java
+++ b/src/test/java/com/github/appreciated/ExampleChartGenerator.java
@@ -16,6 +16,7 @@ import com.github.appreciated.apexcharts.config.plotoptions.builder.RadialBarBui
 import com.github.appreciated.apexcharts.config.plotoptions.hollow.HollowPosition;
 import com.github.appreciated.apexcharts.config.plotoptions.radialbar.builder.*;
 import com.github.appreciated.apexcharts.config.responsive.builder.OptionsBuilder;
+import com.github.appreciated.apexcharts.config.series.SeriesType;
 import com.github.appreciated.apexcharts.config.stroke.Curve;
 import com.github.appreciated.apexcharts.config.stroke.LineCap;
 import com.github.appreciated.apexcharts.config.subtitle.Align;
@@ -41,6 +42,9 @@ public class ExampleChartGenerator {
                 getDonutChart(),
                 getLineChart(),
                 getAreaChart(),
+                getLineAreaChart(),
+                getLineColumnChart(),
+                getLineColumnAreaChart(),
                 getBubbleChart(),
                 getHorizontalBarChart(),
                 getTimelineChart(),
@@ -183,6 +187,115 @@ public class ExampleChartGenerator {
                         .withOpposite(true).build())
                 .withLegend(LegendBuilder.get().withHorizontalAlign(HorizontalAlign.left).build());
         return areaChart;
+    }
+    
+    public ApexCharts getLineAreaChart() {
+    	ApexCharts lineAreaChart = new ApexCharts()
+                .withChart(
+                        ChartBuilder.get()
+                                .withType(Type.line)
+                                .withZoom(ZoomBuilder.get()
+                                        .withEnabled(false)
+                                        .build())
+                                .build())
+                .withColors("#008FFB", "#FEB019")
+                .withDataLabels(DataLabelsBuilder.get()
+                        .withEnabled(false)
+                        .build())
+                .withStroke(StrokeBuilder.get().withCurve(Curve.straight).build())
+                .withSeries(
+                		new Series("INDEX XYZ", SeriesType.area, 30.0, 24.0, 28.0, 20.0, 32.0, 48.0, 88.0, 72.0, 68.0),
+                		new Series("STOCK ABC", SeriesType.line, 10.0, 41.0, 35.0, 51.0, 49.0, 62.0, 69.0, 91.0, 148.0))
+                .withFill(FillBuilder.get()
+                		.withType("solid")
+                		.withOpacity(0.35, 1.0)
+                		.build())
+                .withTitle(TitleSubtitleBuilder.get()
+                        .withText("Fundamental Analysis of Stocks")
+                        .withAlign(Align.left).build())
+                .withSubtitle(TitleSubtitleBuilder.get()
+                        .withText("Price Movements")
+                        .withAlign(Align.left).build())
+                .withLabels(IntStream.range(1, 10).boxed().map(day -> LocalDate.of(2000, 1, day).toString()).toArray(String[]::new))
+                .withXaxis(XAxisBuilder.get()
+                        .withType(XAxisType.datetime).build())
+                .withYaxis(YAxisBuilder.get()
+                        .withOpposite(true).build())
+                .withLegend(LegendBuilder.get().withHorizontalAlign(HorizontalAlign.left).build());
+        return lineAreaChart;
+    }
+    
+    public ApexCharts getLineColumnChart() {
+    	ApexCharts lineAreaChart = new ApexCharts()
+                .withChart(
+                        ChartBuilder.get()
+                                .withType(Type.line)
+                                .withZoom(ZoomBuilder.get()
+                                        .withEnabled(false)
+                                        .build())
+                                .build())
+                .withColors("#008FFB", "#FEB019")
+                .withDataLabels(DataLabelsBuilder.get()
+                        .withEnabled(false)
+                        .build())
+                .withStroke(StrokeBuilder.get().withCurve(Curve.straight).build())
+                .withSeries(
+                		new Series("Sales", SeriesType.column, 11.0, 14.0, 7.0, 2.0, 7.0, 15.0, 26.0, 19.0, 36.0),
+                		new Series("INDEX XYZ", SeriesType.line, 30.0, 24.0, 28.0, 20.0, 32.0, 48.0, 88.0, 72.0, 68.0))
+                .withFill(FillBuilder.get()
+                		.withType("solid")
+                		.withOpacity(1.0, 1.0)
+                		.build())
+                .withTitle(TitleSubtitleBuilder.get()
+                        .withText("Fundamental Analysis of Stocks")
+                        .withAlign(Align.left).build())
+                .withSubtitle(TitleSubtitleBuilder.get()
+                        .withText("Price Movements")
+                        .withAlign(Align.left).build())
+                .withLabels(IntStream.range(1, 10).boxed().map(day -> LocalDate.of(2000, 1, day).toString()).toArray(String[]::new))
+                .withXaxis(XAxisBuilder.get()
+                        .withType(XAxisType.datetime).build())
+                .withYaxis(YAxisBuilder.get()
+                        .withOpposite(false).build())
+                .withLegend(LegendBuilder.get().withHorizontalAlign(HorizontalAlign.left).build());
+        return lineAreaChart;
+    }
+    
+    public ApexCharts getLineColumnAreaChart() {
+    	ApexCharts lineAreaChart = new ApexCharts()
+                .withChart(
+                        ChartBuilder.get()
+                                .withType(Type.line)
+                                .withZoom(ZoomBuilder.get()
+                                        .withEnabled(false)
+                                        .build())
+                                .build())
+                .withColors("#008FFB", "#FEB019", "#775DD0")
+                .withDataLabels(DataLabelsBuilder.get()
+                        .withEnabled(false)
+                        .build())
+                .withStroke(StrokeBuilder.get().withCurve(Curve.straight).build())
+                .withSeries(
+                		new Series("Sales", SeriesType.column, 11.0, 14.0, 7.0, 2.0, 7.0, 15.0, 26.0, 19.0, 36.0),
+                		new Series("INDEX XYZ", SeriesType.line, 30.0, 24.0, 28.0, 20.0, 32.0, 48.0, 88.0, 72.0, 68.0),
+                		new Series("Volumne", SeriesType.area, 41.0, 65.0, 72.0, 74.0, 81.0, 96.0, 132.0, 151.0, 187.0))
+                .withFill(FillBuilder.get()
+                		.withType("solid")
+                		.withOpacity(1.0, 1.0, 0.35)
+                		.build())
+                .withTitle(TitleSubtitleBuilder.get()
+                        .withText("Fundamental Analysis of Stocks")
+                        .withAlign(Align.left).build())
+                .withSubtitle(TitleSubtitleBuilder.get()
+                        .withText("Price Movements")
+                        .withAlign(Align.left).build())
+                .withLabels(IntStream.range(1, 10).boxed().map(day -> LocalDate.of(2000, 1, day).toString()).toArray(String[]::new))
+                .withXaxis(XAxisBuilder.get()
+                        .withType(XAxisType.datetime).build())
+                .withYaxis(YAxisBuilder.get()
+                        .withOpposite(false).build())
+                .withLegend(LegendBuilder.get().withHorizontalAlign(HorizontalAlign.left).build());
+        return lineAreaChart;
     }
 
     public ApexCharts getHorizontalBarChart() {


### PR DESCRIPTION
Hello,

i added support for combining line, area and column Charts freely.
Additional to that I changed Fill & FillBuilder to accept multiple inputs to configure each chart seperatly.
I also added 3 examples to show the usage.

For future adds:
I couldn´t get Scatter Charts with a line chart working and 
the other config options are not yet ready to configure multiple Charts differently.

Sincerely
Maurice Pochzosz