### PR TITLE
2.0.0.beta11: apexcharts version 3.20.0, added dataURI function

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.github.appreciated</groupId>
     <artifactId>apexcharts</artifactId>
-    <version>2.0.0.beta11</version>
+    <version>2.0.0.beta10</version>
     <name>ApexCharts.js</name>
     <description>Integration of ApexCharts.js for the Vaadin platform</description>
 
@@ -157,7 +157,7 @@
                 <configuration>
                     <scanIntervalSeconds>3</scanIntervalSeconds>
                     <!-- Use test scope because the UI/demo classes are in
-                    the test package. -->
+                            the test package. -->
                     <useTestScope>true</useTestScope>
                     <supportedPackagings>
                         <supportedPackaging>jar</supportedPackaging>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.github.appreciated</groupId>
     <artifactId>apexcharts</artifactId>
-    <version>2.0.0.beta10</version>
+    <version>2.0.0.beta11</version>
     <name>ApexCharts.js</name>
     <description>Integration of ApexCharts.js for the Vaadin platform</description>
 
@@ -157,7 +157,7 @@
                 <configuration>
                     <scanIntervalSeconds>3</scanIntervalSeconds>
                     <!-- Use test scope because the UI/demo classes are in
-                            the test package. -->
+                    the test package. -->
                     <useTestScope>true</useTestScope>
                     <supportedPackagings>
                         <supportedPackaging>jar</supportedPackaging>

--- a/src/main/java/com/github/appreciated/apexcharts/ApexCharts.java
+++ b/src/main/java/com/github/appreciated/apexcharts/ApexCharts.java
@@ -12,12 +12,13 @@ import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.CssImport;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
+import com.vaadin.flow.component.page.PendingJavaScriptResult;
 import com.vaadin.flow.component.polymertemplate.PolymerTemplate;
 
 import java.util.Arrays;
 
 @Tag("apex-charts-wrapper")
-@NpmPackage(value = "apexcharts", version = "3.17.0")
+@NpmPackage(value = "apexcharts", version = "3.20.0")
 @NpmPackage(value = "onecolor", version = "3.1.0")
 @JsModule("./com/github/appreciated/apexcharts/apexcharts-wrapper.js")
 @CssImport(value = "./com/github/appreciated/apexcharts/apexcharts-wrapper-styles.css", id = "apex-charts-style")
@@ -153,6 +154,10 @@ public class ApexCharts extends PolymerTemplate<ApexChartsModel> implements HasS
      */
     public void render() {
         getElement().callJsFunction("render");
+    }
+    
+    public PendingJavaScriptResult dataURI() {
+        return getElement().callJsFunction("dataURI");
     }
 
     /**

--- a/src/main/resources/META-INF/resources/frontend/com/github/appreciated/apexcharts/apexcharts-wrapper.js
+++ b/src/main/resources/META-INF/resources/frontend/com/github/appreciated/apexcharts/apexcharts-wrapper.js
@@ -274,6 +274,13 @@ class ApexChartsWrapper extends PolymerElement {
             this.chartComponent.render();
         }
     }
+	
+	dataURI() {
+		if (this.chartComponent) {
+			this.updateConfig();
+			return this.chartComponent.dataURI();
+		}
+	}
 }
 
 customElements.define(ApexChartsWrapper.is, ApexChartsWrapper);


### PR DESCRIPTION
- version updated to 2.0.0.beta11
- apexcharts version 3.17.0 -> 3.20.0 update (fixed png and svg download)
Info about it [here](https://github.com/apexcharts/apexcharts.js/issues/1458).
- added function _dataURI_ to get base64 of chart
It's very useful to save charts to external file e.g. PDF file.
Example usage:
```
            chart.dataURI().then(result -> {
                try {
                    String base64 = new ObjectMapper().readValue(result.toJson(), ImgUriJson.class).getImgURI();
                } catch (Exception ex) {
                    ...
                }
            });
```
Best regards, Maciej.