### PR TITLE
Added support for options.chart.zoom.autoScaleYaxis option

### DIFF
--- a/src/main/java/com/github/appreciated/apexcharts/config/chart/Zoom.java
+++ b/src/main/java/com/github/appreciated/apexcharts/config/chart/Zoom.java
@@ -7,6 +7,7 @@ public class Zoom {
     private Boolean enabled;
     private ZoomType type;
     private ZoomedArea zoomedArea;
+    private Boolean autoScaleYaxis;
 
 
     public Zoom() {
@@ -24,6 +25,10 @@ public class Zoom {
         return zoomedArea;
     }
 
+    public Boolean getAutoScaleYaxis() {
+        return autoScaleYaxis;
+    }
+
     public void setEnabled(Boolean enabled) {
         this.enabled = enabled;
     }
@@ -34,6 +39,10 @@ public class Zoom {
 
     public void setZoomedArea(ZoomedArea zoomedArea) {
         this.zoomedArea = zoomedArea;
+    }
+
+    public void setAutoScaleYaxis(final Boolean autoScaleYaxis) {
+        this.autoScaleYaxis = autoScaleYaxis;
     }
 
 }

--- a/src/main/java/com/github/appreciated/apexcharts/config/chart/builder/ZoomBuilder.java
+++ b/src/main/java/com/github/appreciated/apexcharts/config/chart/builder/ZoomBuilder.java
@@ -8,6 +8,7 @@ public class ZoomBuilder {
     private Boolean enabled;
     private ZoomType type;
     private ZoomedArea zoomedArea;
+    private Boolean autoScaleYaxis;
 
     private ZoomBuilder() {
     }
@@ -31,11 +32,17 @@ public class ZoomBuilder {
         return this;
     }
 
+    public ZoomBuilder withAutoScaleYaxis(Boolean autoScaleYaxis) {
+        this.autoScaleYaxis = autoScaleYaxis;
+        return this;
+    }
+
     public Zoom build() {
         Zoom zoom = new Zoom();
         zoom.setEnabled(enabled);
         zoom.setType(type);
         zoom.setZoomedArea(zoomedArea);
+        zoom.setAutoScaleYaxis(autoScaleYaxis);
         return zoom;
     }
 }


### PR DESCRIPTION
The boolean option `options.chart.zoom.autoScaleYaxis` has been added
Ref: https://apexcharts.com/docs/options/chart/zoom/#autoScaleYaxis

![image](https://user-images.githubusercontent.com/25512513/134821629-12725c3d-9680-496c-b379-827628b09772.png)

```java
ApexChartsBuilder.get()
            .withChart(ChartBuilder.get()
                .withType(Type.line)
                .withZoom(ZoomBuilder.get()
                    .withEnabled(true)
                    .withAutoScaleYaxis(false)
                    .build())
                .build())
```
![image](https://user-images.githubusercontent.com/25512513/134821810-27e285b8-34ae-4d1d-8a86-d6d29ba8f8b6.png)

```java
ApexChartsBuilder.get()
            .withChart(ChartBuilder.get()
                .withType(Type.line)
                .withZoom(ZoomBuilder.get()
                    .withEnabled(true)
                    .withAutoScaleYaxis(true)
                    .build())
                .build())
```
![image](https://user-images.githubusercontent.com/25512513/134821647-121a1f46-a64c-4e02-b0ed-739746d4baea.png)
