### PR TITLE
set minimum required jdk11 in pom.xml - fix jitpack.io build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,8 +11,9 @@
 
     <properties>
         <vaadin.version>23.1.7</vaadin.version>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.release>11</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <jetty.version>9.4.15.v20190215</jetty.version>


### PR DESCRIPTION
Installs node and npm automatically if missing.

This fixes the previously broken jitpack.io build, allowing to directly fetch a compiled nightly build with maven after adding the jitpack repository.


Example usage in pom.xml
```
        <repository>
            <id>jitpack.io</id>
            <url>https://jitpack.io</url>
        </repository>
```
```
        <dependency>
            <groupId>com.github.appreciated</groupId>
            <artifactId>apexcharts-flow</artifactId>
            <version>-SNAPSHOT</version>
        </dependency>
```
