### PR TITLE
Increase build speed by removing maven-clean-plugin. Its not required to delete `node_modules` with every clean build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -204,29 +204,6 @@
                     </webApp>
                 </configuration>
             </plugin>
-            <plugin>
-                <artifactId>maven-clean-plugin</artifactId>
-                <version>3.1.0</version>
-                <configuration>
-                    <filesets>
-                        <fileset>
-                            <directory>.</directory>
-                            <includes>
-                                <include>package.json</include>
-                                <include>package-lock.json</include>
-                            </includes>
-                            <followSymlinks>false</followSymlinks>
-                        </fileset>
-                        <fileset>
-                            <directory>./node_modules</directory>
-                            <includes>
-                                <include>**/**</include>
-                            </includes>
-                            <followSymlinks>false</followSymlinks>
-                        </fileset>
-                    </filesets>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
Increase build speed by removing maven-clean-plugin. Its not required to delete `node_modules` with every clean build

Based on #141 