### PR TITLE
Preparing Release 23.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,12 @@ To deploy to another port set **jetty.port** and/or **jetty.ssl.port** like
 mvn jetty:run -Djetty.port=8090 -Djetty.ssl.port=8555
 ```
 
-### Branching information
+### Version information
 
-* `master` the latest version of the starter, using latest platform snapshot
-* `v10` the version for Vaadin 10
-* `v11` the version for Vaadin 11
-* `v12` the version for Vaadin 12
-* `v13` the version for Vaadin 13
+Release version will follow Vaadin's versioning. eg `23.x.x` indicates it depends on Vaadin 23
+
+* `master` uses Vaadin 23.x.x
+* `v2.0.0-beta13` uses Vaadin 14.x.x
 
 ### License
 


### PR DESCRIPTION
* Update Version Information


Release Notes
* Upgrade Vaadin dependency to 23 LTS (#138)
* Migrate from PolymerTemplate to LitTemplate (#138)
* Include Jandex plugin for Bean Discovery in Quarkus (#138)
* Add Toolbar.Export Object (#137)
* Set minimum required jdk11 (#139)
* Bump Vaadin to 23.2.0 & Project to 2.0.0-beta14 #141)
* Fix onecolor & ShadyCSS (#141)
*  Refactor enums to be uppercase and include `@JsonValue` for correct serialization (#142)
*  Increase build speed by removing `maven-clean-plugin`. Its not required to delete node_modules with every clean build (#143)


After this merge, we can tag v23.0.0 & upload to Vaadin Directory