### PR TITLE
Allow individual series stroke width

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "@vaadin/vaadin-virtual-list": "23.2.0",
     "@vaadin/vertical-layout": "23.2.0",
     "@vaadin/virtual-list": "23.2.0",
-    "apexcharts": "3.30.0",
+    "apexcharts": "3.35.0",
     "construct-style-sheets-polyfill": "3.1.0",
     "date-fns": "2.28.0",
     "lit": "2.3.0",
@@ -226,7 +226,7 @@
       "@vaadin/vaadin-virtual-list": "23.2.0",
       "@vaadin/vertical-layout": "23.2.0",
       "@vaadin/virtual-list": "23.2.0",
-      "apexcharts": "3.30.0",
+      "apexcharts": "3.35.0",
       "construct-style-sheets-polyfill": "3.1.0",
       "date-fns": "2.28.0",
       "lit": "2.3.0",
@@ -247,7 +247,7 @@
       "workbox-core": "6.5.0",
       "workbox-precaching": "6.5.0"
     },
-    "hash": "4eb4f926721e790404b6f47eef798ba26ab913f5bbc9776f54e3f3f803a1fb82"
+    "hash": "0c63fa5cd589fa3bc762bd2dd51aa7f480916363b0999b405fdba5a48490d21f"
   },
   "overrides": {
     "@vaadin/bundles": "$@vaadin/bundles",

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.github.appreciated</groupId>
     <artifactId>apexcharts</artifactId>
-    <version>23.0.0</version>
+    <version>23.0.1</version>
     <name>ApexCharts.js</name>
     <description>Integration of ApexCharts.js for the Vaadin platform 23</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.github.appreciated</groupId>
     <artifactId>apexcharts</artifactId>
-    <version>23.0.1</version>
+    <version>23.0.2</version>
     <name>ApexCharts.js</name>
     <description>Integration of ApexCharts.js for the Vaadin platform 23</description>
 

--- a/src/main/java/com/github/appreciated/apexcharts/ApexCharts.java
+++ b/src/main/java/com/github/appreciated/apexcharts/ApexCharts.java
@@ -21,7 +21,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 @Tag("apex-charts-wrapper")
-@NpmPackage(value = "apexcharts", version = "3.30.0")
+@NpmPackage(value = "apexcharts", version = "3.35.0")
 @NpmPackage(value = "onecolor", version = "3.1.0")
 @JsModule("./com/github/appreciated/apexcharts/apexcharts-wrapper.ts")
 @CssImport(value = "./com/github/appreciated/apexcharts/apexcharts-wrapper-styles.css", id = "apex-charts-style")
@@ -105,6 +105,10 @@ public class ApexCharts extends LitTemplate implements HasSize, HasStyle, HasThe
 
     public void setLegend(Legend legend) {
         setPropertyObject("legend", legend);
+    }
+
+    public void setForecastDataPoints(ForecastDataPoints forecastDataPoints) {
+        setPropertyObject("forecastDataPoints", forecastDataPoints);
     }
 
     public void setMarkers(Markers markers) {

--- a/src/main/java/com/github/appreciated/apexcharts/ApexChartsBuilder.java
+++ b/src/main/java/com/github/appreciated/apexcharts/ApexChartsBuilder.java
@@ -6,6 +6,7 @@ import com.github.appreciated.apexcharts.config.Annotations;
 import com.github.appreciated.apexcharts.config.Chart;
 import com.github.appreciated.apexcharts.config.DataLabels;
 import com.github.appreciated.apexcharts.config.Fill;
+import com.github.appreciated.apexcharts.config.ForecastDataPoints;
 import com.github.appreciated.apexcharts.config.Grid;
 import com.github.appreciated.apexcharts.config.Legend;
 import com.github.appreciated.apexcharts.config.Markers;
@@ -28,6 +29,7 @@ public class ApexChartsBuilder {
     private String[] colors;
     private DataLabels dataLabels;
     private Fill fill;
+    private ForecastDataPoints forecastDataPoints;
     private Grid grid;
     private String[] labels;
     private Legend legend;
@@ -89,6 +91,11 @@ public class ApexChartsBuilder {
 
     public ApexChartsBuilder withFill(Fill fill) {
         this.fill = fill;
+        return this;
+    }
+
+    public ApexChartsBuilder withForecastDataPoints(ForecastDataPoints forecastDataPoints) {
+        this.forecastDataPoints = forecastDataPoints;
         return this;
     }
 
@@ -226,6 +233,9 @@ public class ApexChartsBuilder {
         }
         if (fill != null) {
             apexCharts.setFill(fill);
+        }
+        if (forecastDataPoints != null) {
+            apexCharts.setForecastDataPoints(forecastDataPoints);
         }
         if (grid != null) {
             apexCharts.setGrid(grid);

--- a/src/main/java/com/github/appreciated/apexcharts/config/ForecastDataPoints.java
+++ b/src/main/java/com/github/appreciated/apexcharts/config/ForecastDataPoints.java
@@ -1,0 +1,15 @@
+package com.github.appreciated.apexcharts.config;
+
+
+public class ForecastDataPoints {
+    Integer count = 0;
+
+    public Integer getCount() {
+        return count;
+    }
+
+    public void setCount(Integer count) {
+        this.count = count;
+    }
+
+}

--- a/src/main/java/com/github/appreciated/apexcharts/config/Stroke.java
+++ b/src/main/java/com/github/appreciated/apexcharts/config/Stroke.java
@@ -1,5 +1,7 @@
 package com.github.appreciated.apexcharts.config;
 
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.github.appreciated.apexcharts.config.stroke.Curve;
 import com.github.appreciated.apexcharts.config.stroke.LineCap;
 
@@ -10,7 +12,10 @@ public class Stroke {
     private Curve curve;
     private LineCap lineCap;
     private List<String> colors;
+    @JsonIgnore
     private Double width;
+    @JsonIgnore
+    private List<Double> widthArray;
     private List<Double> dashArray;
 
 
@@ -37,6 +42,10 @@ public class Stroke {
         return width;
     }
 
+    public List<Double> getWidthArray() {
+        return widthArray;
+    }
+
     public List<Double> getDashArray() {
         return dashArray;
     }
@@ -61,8 +70,20 @@ public class Stroke {
         this.width = width;
     }
 
+    public void setWidthArray(List<Double> widthArray) {
+        this.widthArray = widthArray;
+    }
+
     public void setDashArray(List<Double> dashArray) {
         this.dashArray = dashArray;
+    }
+
+    @JsonGetter("width")
+    public Object serializeWidth() {
+        if (width != null) {
+            return width;
+        }
+        return widthArray;
     }
 
 }

--- a/src/main/java/com/github/appreciated/apexcharts/config/builder/ForecastDataPointsBuilder.java
+++ b/src/main/java/com/github/appreciated/apexcharts/config/builder/ForecastDataPointsBuilder.java
@@ -1,0 +1,27 @@
+package com.github.appreciated.apexcharts.config.builder;
+
+import com.github.appreciated.apexcharts.config.ForecastDataPoints;
+
+public class ForecastDataPointsBuilder {
+    Integer count;
+
+    public static ForecastDataPointsBuilder get() {
+        return new ForecastDataPointsBuilder();
+    }
+
+
+    public ForecastDataPointsBuilder withCount(Integer count) {
+        this.count = count;
+        return this;
+    }
+
+
+    public ForecastDataPoints build() {
+        ForecastDataPoints forecast = new ForecastDataPoints();
+        if (count != null) {
+            forecast.setCount(count);
+        }
+        return forecast;
+    }
+
+}

--- a/src/main/java/com/github/appreciated/apexcharts/config/builder/StrokeBuilder.java
+++ b/src/main/java/com/github/appreciated/apexcharts/config/builder/StrokeBuilder.java
@@ -13,6 +13,7 @@ public class StrokeBuilder {
     private LineCap lineCap;
     private List<String> colors;
     private Double width;
+    private List<Double> widthArray;
     private List<Double> dashArray;
 
     private StrokeBuilder() {
@@ -47,6 +48,16 @@ public class StrokeBuilder {
         return this;
     }
 
+    public StrokeBuilder withWidthArray(List<Double> widthArray) {
+        this.widthArray = widthArray;
+        return this;
+    }
+
+    public StrokeBuilder withWidthArray(Double... widths) {
+        this.widthArray = List.of(widths);
+        return this;
+    }
+
     public StrokeBuilder withDashArray(List<Double> dashArray) {
         this.dashArray = dashArray;
         return this;
@@ -59,6 +70,7 @@ public class StrokeBuilder {
         stroke.setLineCap(lineCap);
         stroke.setColors(colors);
         stroke.setWidth(width);
+        stroke.setWidthArray(widthArray);
         stroke.setDashArray(dashArray);
         return stroke;
     }

--- a/src/main/resources/META-INF/resources/frontend/com/github/appreciated/apexcharts/apexcharts-wrapper.ts
+++ b/src/main/resources/META-INF/resources/frontend/com/github/appreciated/apexcharts/apexcharts-wrapper.ts
@@ -31,6 +31,9 @@ export class ApexChartsWrapper extends LitElement {
             fill: {
                 type: Object
             }, // ApexFill;
+            forecastDataPoints: {
+                type: Object
+            }, // ApexForecastDataPoints;
             grid: {
                 type: Object
             }, // ApexGrid;
@@ -200,6 +203,9 @@ export class ApexChartsWrapper extends LitElement {
         }
         if (this.fill) {
             this.config.fill = JSON.parse(this.fill);
+        }
+        if (this.forecastDataPoints) {
+            this.config.forecastDataPoints = JSON.parse(this.forecastDataPoints);
         }
         if (this.grid) {
             this.config.grid = JSON.parse(this.grid);

--- a/src/test/java/com/github/appreciated/apexcharts/examples/line/LineChartExample.java
+++ b/src/test/java/com/github/appreciated/apexcharts/examples/line/LineChartExample.java
@@ -1,10 +1,8 @@
 package com.github.appreciated.apexcharts.examples.line;
 
 import com.github.appreciated.apexcharts.ApexChartsBuilder;
-import com.github.appreciated.apexcharts.config.builder.ChartBuilder;
-import com.github.appreciated.apexcharts.config.builder.GridBuilder;
-import com.github.appreciated.apexcharts.config.builder.StrokeBuilder;
-import com.github.appreciated.apexcharts.config.builder.XAxisBuilder;
+import com.github.appreciated.apexcharts.config.ForecastDataPoints;
+import com.github.appreciated.apexcharts.config.builder.*;
 import com.github.appreciated.apexcharts.config.chart.Type;
 import com.github.appreciated.apexcharts.config.chart.builder.ZoomBuilder;
 import com.github.appreciated.apexcharts.config.grid.builder.RowBuilder;
@@ -28,6 +26,7 @@ public class LineChartExample extends ApexChartsBuilder {
                                 .withColors("#f3f3f3", "transparent")
                                 .withOpacity(0.5).build()
                         ).build())
+                .withForecastDataPoints(ForecastDataPointsBuilder.get().withCount(2).build())
                 .withXaxis(XAxisBuilder.get()
                         .withCategories("Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep")
                         .withTickPlacement(TickPlacement.BETWEEN)

--- a/src/test/java/com/github/appreciated/apexcharts/examples/line/LineChartExample.java
+++ b/src/test/java/com/github/appreciated/apexcharts/examples/line/LineChartExample.java
@@ -1,7 +1,6 @@
 package com.github.appreciated.apexcharts.examples.line;
 
 import com.github.appreciated.apexcharts.ApexChartsBuilder;
-import com.github.appreciated.apexcharts.config.ForecastDataPoints;
 import com.github.appreciated.apexcharts.config.builder.*;
 import com.github.appreciated.apexcharts.config.chart.Type;
 import com.github.appreciated.apexcharts.config.chart.builder.ZoomBuilder;

--- a/src/test/java/com/github/appreciated/apexcharts/examples/line/LineMultiYAxesChartExample.java
+++ b/src/test/java/com/github/appreciated/apexcharts/examples/line/LineMultiYAxesChartExample.java
@@ -6,10 +6,11 @@ import com.github.appreciated.apexcharts.config.chart.Type;
 import com.github.appreciated.apexcharts.config.chart.builder.ZoomBuilder;
 import com.github.appreciated.apexcharts.config.grid.builder.RowBuilder;
 import com.github.appreciated.apexcharts.config.stroke.Curve;
-import com.github.appreciated.apexcharts.config.yaxis.AxisBorder;
 import com.github.appreciated.apexcharts.config.yaxis.builder.AxisBorderBuilder;
 import com.github.appreciated.apexcharts.config.yaxis.builder.TitleBuilder;
 import com.github.appreciated.apexcharts.helper.Series;
+
+import java.util.List;
 
 public class LineMultiYAxesChartExample extends ApexChartsBuilder {
     public LineMultiYAxesChartExample() {
@@ -21,6 +22,7 @@ public class LineMultiYAxesChartExample extends ApexChartsBuilder {
                 .build())
                 .withStroke(StrokeBuilder.get()
                         .withCurve(Curve.STRAIGHT)
+                        .withWidthArray(List.of(6.0, 3.0))
                         .build())
                 .withGrid(GridBuilder.get()
                         .withRow(RowBuilder.get()


### PR DESCRIPTION
Add the option to either set a fixed width for all lines (as always) or individually per series as an array of widths.

Some marshalling tricks were needed as the `width` property can either be an array or a number.

If both set, the width has preference over the array.

Bump version to 23.0.2

Resolves #149 