### PR TITLE
Update ApexCharts.js from 3.45.1 to 3.49.0

### DIFF
--- a/src/main/java/com/github/appreciated/apexcharts/ApexCharts.java
+++ b/src/main/java/com/github/appreciated/apexcharts/ApexCharts.java
@@ -21,7 +21,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 @Tag("apex-charts-wrapper")
-@NpmPackage(value = "apexcharts", version = "3.45.1")
+@NpmPackage(value = "apexcharts", version = "3.49.0")
 @NpmPackage(value = "onecolor", version = "4.1.0")
 @JsModule("./com/github/appreciated/apexcharts/apexcharts-wrapper.ts")
 @CssImport(value = "./com/github/appreciated/apexcharts/apexcharts-wrapper-styles.css", id = "apex-charts-style")


### PR DESCRIPTION
I would like to update the JavaScript Libraries version. There have been some Bugfixes (e.g when displaying barcharts). 

Patchnotes since 3.45.1 can be found here: 
https://github.com/apexcharts/apexcharts.js/releases

