### PR TITLE
SeriesBuilder missing generics parameter #185

### DIFF
--- a/src/main/java/com/github/appreciated/apexcharts/config/builder/SeriesBuilder.java
+++ b/src/main/java/com/github/appreciated/apexcharts/config/builder/SeriesBuilder.java
@@ -11,8 +11,8 @@ public class SeriesBuilder<T> {
     private SeriesBuilder() {
     }
 
-    public static SeriesBuilder<?> get() {
-        return new SeriesBuilder();
+    public static <T> SeriesBuilder<T> get() {
+        return new SeriesBuilder<>();
     }
 
     public SeriesBuilder<T> withName(String name) {

--- a/src/test/java/com/github/appreciated/apexcharts/examples/line/LineChartExample.java
+++ b/src/test/java/com/github/appreciated/apexcharts/examples/line/LineChartExample.java
@@ -29,6 +29,9 @@ public class LineChartExample extends ApexChartsBuilder {
                         .withCategories("Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep")
                         .withTickPlacement(TickPlacement.BETWEEN)
                         .build())
-                .withSeries(new Series<>("Desktops", 10.0, 41.0, 35.0, 51.0, 49.0, 62.0, 69.0, 91.0, 148.0));
+                .withSeries(SeriesBuilder.get()
+                                    .withName("Desktops")
+                                    .withData(10.0, 41.0, 35.0, 51.0, 49.0, 62.0, 69.0, 91.0, 148.0)
+                                    .build());
     }
 }


### PR DESCRIPTION
This is a possible solution to #185, changing the SeriesBuilder.get() method to account for the generic type of SeriesBuilder.java.